### PR TITLE
fix sed step in selective alignment tutorial

### DIFF
--- a/docs/_posts/2019-30-10-selective-alignment.md
+++ b/docs/_posts/2019-30-10-selective-alignment.md
@@ -34,7 +34,7 @@ Salmon indexing requires the names of the genome targets, which is extractable b
 
 ```python
 grep "^>" <(zcat GRCm38.primary_assembly.genome.fa.gz) | cut -d " " -f 1 > decoys.txt
-sed -i -e 's/>//g' decoys.txt
+sed -i.bak -e 's/>//g' decoys.txt
 ```
 
 Along with the list of decoys salmon also needs the concatenated transcriptome and genome reference file for index.


### PR DESCRIPTION
on macOS having no arguments after `-i` option in `sed` leads to `-i` consuming the following characters as arguments (in this case `-e`). 

My fix makes it platform independent, but leaves a backup file. So you may want to remove it in the tutorial.